### PR TITLE
don't build examples by default and prepare github actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,24 @@
+name: Build and Test
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependencies library and prepare dependency folder
+      run: sudo apt-get install libeigen3-dev libasound2-dev libusb-1.0.0-dev freeglut3-dev xorg-dev libglew-dev
+
+    - name: Build Chai3d
+      run: |
+        mkdir build && cd build
+        cmake .. && make -j8
+
+    - name: Check build status
+      run: |
+        cd build
+        make --always-make --dry-run

--- a/.github/workflows/upload_artifact_on_schedule.yml
+++ b/.github/workflows/upload_artifact_on_schedule.yml
@@ -1,0 +1,23 @@
+name: Build master and upload artifact on a schedule
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+      branches: [ "master" ]
+  workflow_dispatch:
+
+jobs:
+  call-build-workflow:
+    uses: ./.github/workflows/build_and_test.yml
+
+  upload-artifact:
+    needs: call-build-workflow
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Archive chai3d Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: chai3d-artifact
+        path: build/libchai3d.a

--- a/.github/workflows/verify_PR.yml
+++ b/.github/workflows/verify_PR.yml
@@ -1,0 +1,11 @@
+name: Verify PR builds
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  call-build-workflow:
+    uses: ./.github/workflows/build_and_test.yml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,9 @@ if (NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Release CACHE STRING "Setting build mode to Release" FORCE)
 endif()
 
+# build examples and extras
+option(BUILD_EXAMPLES "Build examples" OFF)
+
 # output location
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY                ${PROJECT_SOURCE_DIR}/bin/${OS}-${ARCH})
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG          ${PROJECT_SOURCE_DIR}/bin/${OS}-${ARCH})
@@ -84,6 +87,7 @@ set (CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE        ${PROJECT_SOURCE_DIR}/bin/${O
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${PROJECT_SOURCE_DIR}/bin/${OS}-${ARCH})
 
 # OpenGL dependency
+set(OpenGL_GL_PREFERENCE "GLVND")
 find_package (OpenGL REQUIRED)
 include_directories (OPENGL_INCLUDE_DIR)
 
@@ -231,26 +235,28 @@ set (CHAI3D_SOURCE_DIR ${PROJECT_SOURCE_DIR})
 # optional extras
 #
 
-# GLFW
-if (EXISTS ${PROJECT_SOURCE_DIR}/extras/GLFW)
-  add_subdirectory (${PROJECT_SOURCE_DIR}/extras/GLFW)
-endif ()
+if(BUILD_EXAMPLES)
 
+  # GLFW
+  if (EXISTS ${PROJECT_SOURCE_DIR}/extras/GLFW)
+    add_subdirectory (${PROJECT_SOURCE_DIR}/extras/GLFW)
+  endif ()
 
-#
-# executables
-#
+  #
+  # executables
+  #
 
-# examples
-if (EXISTS ${PROJECT_SOURCE_DIR}/examples)
-  add_subdirectory (${PROJECT_SOURCE_DIR}/examples)
-endif ()
+  # examples
+  if (EXISTS ${PROJECT_SOURCE_DIR}/examples)
+    add_subdirectory (${PROJECT_SOURCE_DIR}/examples)
+  endif ()
 
-# utilities
-if (EXISTS ${PROJECT_SOURCE_DIR}/utils)
-  add_subdirectory (${PROJECT_SOURCE_DIR}/utils)
-endif ()
+  # utilities
+  if (EXISTS ${PROJECT_SOURCE_DIR}/utils)
+    add_subdirectory (${PROJECT_SOURCE_DIR}/utils)
+  endif ()
 
+endif()
 
 #
 # export package


### PR DESCRIPTION
removed example building by default (needs to be explicitely passed to cmake now)
added a default opengl library find to remove warning
added github workflows to test PRs